### PR TITLE
1.0.5 fix.

### DIFF
--- a/ModuleAnimatedDecoupler.cs
+++ b/ModuleAnimatedDecoupler.cs
@@ -239,8 +239,12 @@ namespace AnimatedDecoupler
 		//
 		public bool IsMoving ()
 		{
-			if ((object)anim != null) {
-				return anim.IsPlaying (animationName);
+			if (animationName != "") {
+				if (anim != null) {
+					return anim.IsPlaying (animationName);
+				} else {
+					return false;
+				}
 			} else {
 				return false;
 			}


### PR DESCRIPTION
One more check to avoid NullReferenceExceptions and breakage.  Tests OK in 1.0.5 with Modular Rocket Systems shroud.
