### PR TITLE
Increment max KSP version to 1.2.2

### DIFF
--- a/GameData/AnimatedDecouplers/AnimatedDecouplers.version
+++ b/GameData/AnimatedDecouplers/AnimatedDecouplers.version
@@ -32,6 +32,6 @@
 	{
 		"MAJOR": 1,
 		"MINOR": 2,
-		"PATCH": 1
+		"PATCH": 2
 	}
 }


### PR DESCRIPTION
Testing confirms that AnimatedDecouplers 1.3.2.1 works fine on KSP 1.2.2.

Updating the AD version file would allow it (and SDHI SMS) to be reindexed in CKAN.